### PR TITLE
Extraction of the data present in the root.

### DIFF
--- a/mhpf-tools.py
+++ b/mhpf-tools.py
@@ -1,6 +1,7 @@
-# Melbourne House Pack File packer/repacker by Chris Torrella
+﻿# Melbourne House Pack File packer/repacker by Chris Torrella
 
-import sys, getopt, os, errno, math, re, struct, json
+import sys, getopt, os, errno, math, re, struct, json, contextlib
+
 
 ############################################################
 # UN-packing functions
@@ -30,8 +31,12 @@ resource_content_locations = []
 resource_dest_lengths = []
 resource_dest_strings = []
 
+
+
 def littleBytesToInt(bytes):
     return int.from_bytes(bytes, "little", signed=False)
+
+
 
 def readHeader(): # reads the first 52 bytes of the file, gives locations of tables
     for key in headerLocations:
@@ -89,12 +94,10 @@ def printTable1():
         # print(str(resource_content_locations[i]) + ", " + resource_dest_strings[i])
         print(str(resource_content_locations[i].get("unknown")) + ", " + str(resource_content_locations[i].get("start")) + ", " + str(resource_content_locations[i].get("size")) + ", \"" + resource_dest_strings[i] + "\"," )
 
+
 def mkdir(path):
-    try:
+ with contextlib.suppress(OSError):
         os.makedirs(path)
-    except OSError as e:
-        if e.errno != errno.EEXIST:
-            raise
 
 def safe_open_w(path):
     ''' Open "path" for writing, creating any parent directories as needed.


### PR DESCRIPTION
While trying to unpack the files of one of the beta versions of TDU.

There were some files present in the root.

The problem with this code was that if the script found them, it could not recover them correctly. 

Result: FileNotFoundError: [WinError 3] The system cannot find the path specified: '' 

After searching, I found a lead in the mkdir definition.

I had noticed that it was already using an error exception approach.
Noticing that it didn't work with root files, I tried to use the new function present since Python 3.4.

Thanks to this, we went from that : 

![Problem](https://user-images.githubusercontent.com/42487204/115882996-9853d500-a44d-11eb-92a5-539edd3ca4df.png)

to this : 
![Solution](https://user-images.githubusercontent.com/42487204/115883058-a6a1f100-a44d-11eb-937d-fbae89fe7d73.png)

Voilà !

I hope I could help you with this.
- JMF386
